### PR TITLE
Change %Ld to %lld in PluginManager#GetConfig

### DIFF
--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -2662,7 +2662,7 @@ bool PluginManager::GetConfig(const wxString & key, sampleCount & value, sampleC
       wxString wxval = wxEmptyString;
       wxString wxdef;
       wchar_t *endptr;
-      wxdef.Printf(wxT("%Ld"), defval);
+      wxdef.Printf(wxT("%lld"), defval);
 
       result = GetSettings()->Read(key, &wxval, wxdef);
       value = wxStrtoll(wxval.c_str(), &endptr, 10);


### PR DESCRIPTION
The VS2015 compiler fails to recognize the `%Ld` format specifier, and I honestly can't find any documentation on the use of `%Ld` via Google / cplusplus.com / Stack Overflow, etc. It works in GCC and G++, and apparently other versions of msvc. As far as I can tell, the intent is to print a 64-bit integer, which is the purpose of `%lld`. This works in VS2015, and I can't imagine it breaks anyone else.
